### PR TITLE
v0.9.4 - Forward and Grading

### DIFF
--- a/index.html
+++ b/index.html
@@ -722,6 +722,20 @@
             border: 0.1rem solid rgba(var(--rgb-bw), 0.2);
             padding: 0.1rem;
         }
+
+        #sheet-view input {
+            border-radius: 0.2rem;
+            border: 0.1rem solid rgba(var(--rgb-bw), 0.2);
+            padding: 0.1rem;
+        }
+
+        #sheet-view .log-input {
+            width: 100%;
+        }
+
+        #sheet-view .grade-input {
+            width: 2rem;
+        }
     </style>
 
 <script id="floGlobals">
@@ -898,7 +912,7 @@
                     <textarea name="writers" placeholder="Writers** [line separated]"></textarea></div>
                 <div class="input-container i-1"><textarea name="columns" placeholder="Columns* [line separated]"
                         required></textarea></div>
-                <span class="asterisk-notation">*Required<br />**(Blank field) Default subAdmin</span>
+                <span class="asterisk-notation">*Required<br />**(Blank field) = Default subAdmin, ('Public') = Public sheet</span>
                 <div class="input-container i-2">
                     <input type="submit" value="Create" />
                     <input type="reset" value="Reset" />
@@ -958,8 +972,9 @@
                     <p></p>
                     <button id="view-group-by">Groupby</button>
                 </div>
-                <form class="table-container" id="sheet-view" onsubmit="enterLog(); return false;"></form>
-                <button type="submit" form="sheet-view" style="display: none;"></button>
+                <div class="table-container" id="sheet-view"></div>
+                <form id="new-log" style="display: none;" onsubmit="enterLog(); return false;"></form>
+                <button type="submit" form="new-log" style="display: none;"></button>
             </div>
         </div>
 
@@ -1037,22 +1052,20 @@
         })
 
         document.getElementById('group-by-menu').children[0].addEventListener("change", function (e) {
-
             try {
                 let title = document.getElementById("sheet-details").children[0].textContent;
+                let sheet = JSON.parse(document.getElementById("sheet-details").dataset.sheet);
                 let type = this.value;
                 if (type === 'count') {
                     this.nextSibling.classList.add("hide")
-                    let data = logSheet.groupLogsBy.count(title)
+                    let data = logSheet.groupLogsBy.count(title, sheet)
                     renderGroupByView("count", data)
                 } else {
                     this.nextSibling.classList.remove("hide")
                     let column = this.nextSibling.value;
-                    let data = logSheet.groupLogsBy[type](title, column);
+                    let data = logSheet.groupLogsBy[type](title, sheet, column);
                     renderGroupByView(`${type}(${column})`, data)
                 }
-
-
             } catch (error) {
                 showMessage(error, "error")
             }
@@ -1061,15 +1074,15 @@
         document.getElementById('group-by-menu').children[1].addEventListener("change", function (e) {
             try {
                 let title = document.getElementById("sheet-details").children[0].textContent;
+                let sheet = JSON.parse(document.getElementById("sheet-details").dataset.sheet);
                 let type = this.previousSibling.value;
                 let column = this.value;
-                let data = logSheet.groupLogsBy[type](title, column);
+                let data = logSheet.groupLogsBy[type](title, sheet, column);
                 renderGroupByView(`${type}(${column})`, data)
             } catch (error) {
                 showMessage(error, "error")
             }
         })
-
 
         function removeElement(element) {
             element.parentNode.removeChild(element);
@@ -1174,10 +1187,12 @@
                 let description = form.description.value.trim();
                 let columns = form.columns.value.trim().split('\n');
                 let writers = form.writers.value.trim();
-                if (writers === '')
-                    writers = floGlobals.subAdmins
+                if(writers === '')
+                    writers = floGlobals.subAdmins;
+                else if(writers.toUpperCase() === 'PUBLIC')
+                    writers = null;
                 else
-                    writers = writers.split('\n')
+                    writers = writers.split('\n').filter(i => floCrypto.validateAddr(i))
                 logSheet.createNewSheet(title, description, columns, writers)
                 renderSheetList([title])
                 form.reset()
@@ -1189,7 +1204,7 @@
         }
 
         function copyToLogInput(floID) {
-            let input = document.forms['sheet-view'][0]
+            let input = document.forms['new-log'][0]
             if (input.tagName === 'INPUT')
                 input.value = floID;
             console.log(floID, input)
@@ -1197,7 +1212,7 @@
 
         function enterLog() {
             let title = document.getElementById("sheet-details").children[0].textContent;
-            let form = document.forms['sheet-view']
+            let form = document.forms['new-log']
             if (form[0].tagName === 'INPUT') {
                 let floID = form[0].value;
                 let log = []
@@ -1207,9 +1222,9 @@
                     form.reset();
                     showMessage('Log Entry Successful')
                     let row = document.getElementById("sheet-view").getElementsByTagName("tbody")[0].insertRow(1);
-                    row.insertCell(0).textContent = floID
-                    for (let k = 0; k < log.length; k++)
-                        row.insertCell(k + 1).textContent = log[k]
+                    row.insertCell().textContent = floID
+                    row.insertCell().innerHTML = `<input type="text" class="grade-input" disabled>`
+                    log.forEach(l => row.insertCell().textContent = l)
                 }).catch(error => showMessage(error, "error"))
             }
         }
@@ -1218,7 +1233,7 @@
             logSheet.refreshLogs(title).then(result => {
                 let data = logSheet.viewLogs(title)
                 renderSheetView(data.title, data.description, data.editors, data.attributes, data.sheet, 
-                    data.editors? data.editors.includes(myFloID) : true)
+                    !data.editors || data.editors.includes(myFloID), floGlobals.subAdmins.includes(myFloID))
             }).catch(error => showMessage(error, "error"))
         }
 
@@ -1260,38 +1275,63 @@
             })
         }
 
-        function renderSheetView(title, description, editors, attributes, sheet, isWriteable) {
+        function renderSheetView(title, description, editors, attributes, sheet, isWriteable, isSubAdmin) {
             const parseVectorClock = (vc) => {
                 vc = vc.split('_')
-                console.log(vc)
                 let time = new Date(parseInt(vc[0])).toString().slice(4, 24);
                 let floID = vc[1]
                 return `by ${floID} (${time})`
             }
+            const createGradeField = (vc, grade) => {
+                let gradeField = document.createElement("input")
+                gradeField.setAttribute("type", "text")
+                gradeField.className = "grade-input"
+                gradeField.value = grade
+                if(!isWriteable || !isSubAdmin || vc.split('_')[1] == myFloID)
+                    gradeField.disabled = true;
+                else{
+                    gradeField.addEventListener("keypress", (event) => {
+                        if (event.keyCode == 13){
+                            event.preventDefault();
+                            gradeField.disabled = true;
+                            logSheet.forwardLog(title, vc, gradeField.value)
+                                .then(result => showMessage("Graded Log"))
+                                .catch(error => showMessage("Grading failed: "+error, "error"))
+                                .finally(_=> gradeField.disabled = false)
+                        }
+                    })
+                }    
+                return gradeField
+            }
+
             //Add Sheet Details
             let sheetDetails = document.getElementById("sheet-details")
             sheetDetails.classList.remove("hide")
             sheetDetails.children[0].textContent = title;
             sheetDetails.children[1].textContent = editors || "Public";
             sheetDetails.children[2].textContent = description;
+            sheetDetails.dataset.sheet = JSON.stringify(sheet);
             //Create and add the sheet table
             let table = document.createElement("table")
             let thead = table.createTHead()
             let head = thead.insertRow(0)
-            head.insertCell(0).textContent = "FLO ID"
+            head.insertCell().textContent = "FLO ID";
+            head.insertCell().textContent = "Grade";
             attributes.forEach(a => head.insertCell().textContent = a)
             let tbody = document.createElement("tbody")
             sheet.forEach(data => {
                 let row = tbody.insertRow(0);
                 row.setAttribute("title", parseVectorClock(data.vc))
-                row.insertCell(0).textContent = data.floID
+                row.insertCell().textContent = data.floID
+                row.insertCell().appendChild(createGradeField(data.vc, data.grade));
                 data.log.forEach(l => row.insertCell().textContent = l)
             })
             //Add input fields if writable
             if (isWriteable) {
                 let row = tbody.insertRow(0);
-                row.insertCell(0).innerHTML = `<input type="text">`;
-                attributes.forEach(a => row.insertCell().innerHTML = `<input type="text">`);
+                row.insertCell().innerHTML = `<input form="new-log" class="log-input" type="text">`;
+                row.insertCell().textContent = ``;
+                attributes.forEach(a => row.insertCell().innerHTML = `<input form="new-log" class="log-input" type="text">`);
             }
             table.appendChild(tbody);
             clearElement(document.getElementById("sheet-view")).appendChild(table);
@@ -1324,19 +1364,23 @@
         }
 
         function sortTable(table, n) {
-            console.log(table, n)
             let dir = "DESC";
             let flag = false;
-            let startRow = (table.getElementsByTagName("INPUT").length === 0) ? 1 : 2
+            let startRow = (table.getElementsByClassName("log-input").length === 0) ? 1 : 2
             while (true) {
                 let rows = table.rows;
                 let swapIndex = false;
-                console.log(rows)
                 for (let i = startRow; i < rows.length - 1; i++) {
-                    let x = rows[i].getElementsByTagName("TD")[n].textContent;
-                    let y = rows[i + 1].getElementsByTagName("TD")[n].textContent;
-                    let x_ = parseFloat(x)
-                    let y_ = parseFloat(y)
+                    let x, y, x_, y_;
+                    if(n === 1){
+                        x = rows[i].getElementsByTagName("TD")[n].children[0].value;
+                        y = rows[i + 1].getElementsByTagName("TD")[n].children[0].value;
+                    } else {
+                        x = rows[i].getElementsByTagName("TD")[n].textContent;
+                        y = rows[i + 1].getElementsByTagName("TD")[n].textContent;
+                    }
+                    x_ = parseFloat(x)
+                    y_ = parseFloat(y)
                     if (isNaN(x_) || isNaN(y_)) {
                         x_ = x.toLowerCase()
                         y_ = y.toLowerCase()
@@ -10594,8 +10638,12 @@ Bitcoin.Util = {
             }
         },
 
-        manageSheetControl(addList, rmList){
-            let editorList = floGlobals.appObjects.logSheet.sheetList[title].editors
+        manageSheetControl(title, addList, rmList){
+            if(addList === null && rmList === null){
+                floGlobals.appObjects.logSheet.sheetList[title].editors = null
+                return
+            }
+            let editorList = floGlobals.appObjects.logSheet.sheetList[title].editors || [];
             if(Array.isArray(addList))
                 addList.forEach(e => editorList.includes(e) ? null: editorList.push(e))
             if(Array.isArray(rmList))
@@ -10630,7 +10678,36 @@ Bitcoin.Util = {
                         return reject("floID not found");
                 } else if(!floGlobals.subAdmins.includes(myFloID) && floID != myFloID)
                         return reject("Public authorized to log their own floID only");
-                floCloudAPI.sendGeneralData({floID: floID, log: log}, title)
+                floCloudAPI.sendGeneralData({floID, log}, title)
+                    .then(result => resolve(result))
+                    .catch(error => reject(error))
+            })
+        },
+
+        forwardLog(title, vc, grade) {
+            return new Promise((resolve, reject) => {
+                //reject if user is not subAdmin or editor
+                if(!floGlobals.subAdmins.includes(myFloID) || 
+                (floGlobals.appObjects.logSheet.sheetList[title].editors && 
+                !floGlobals.appObjects.logSheet.sheetList[title].editors.includes(myFloID)))
+                    return reject("Only subAdmins in editor list can forward/grade logs")
+                    
+                let filter = floDapps.util.getFilterString(title)
+                let forward = null
+                for(let row of floGlobals.generalData[filter]){
+                    if(row.vectorClock === vc){
+                        forward = row;
+                        break;
+                    } else if (row.message.forward && row.message.forward.vectorClock === vc){
+                        forward = row.message.forward;
+                        break;
+                    }
+                }
+                if(!forward)
+                    return reject("Log not found")
+                if(forward.sender === myFloID)
+                    return reject("Cannot grade own log")
+                floCloudAPI.sendGeneralData({forward, grade}, title)
                     .then(result => resolve(result))
                     .catch(error => reject(error))
             })
@@ -10651,13 +10728,43 @@ Bitcoin.Util = {
         viewLogs(title){
             if(!(title in floGlobals.appObjects.logSheet.sheetList))
                 throw ("Sheet not found")
-            let sheet = []
-            let filter = floDapps.util.getFilterString(title)
-            floGlobals.generalData[filter].forEach(l => sheet.push({
-                vc: l.vectorClock,
-                floID: l.message.floID,
-                log: l.message.log
-            }))
+            let sheet = [],
+            vcIndex = {},
+            filter = floDapps.util.getFilterString(title),
+            editors = floGlobals.appObjects.logSheet.sheetList[title].editors;
+
+            floGlobals.generalData[filter].forEach(l => {
+                if((!editors || editors.includes(l.sender))) {
+                    if(l.message.forward){
+                        if(floGlobals.subAdmins.includes(l.sender) && 
+                        l.sender != l.message.forward.sender) {
+                            let vc = l.message.forward.vectorClock
+                            if(vc in vcIndex)
+                                sheet[vcIndex[vc]].grade = l.message.grade;
+                            else if(floCrypto.validateAddr(l.message.forward.floID)){
+                                sheet.push({
+                                    vc: vc,
+                                    floID: l.message.forward.floID,
+                                    log: l.message.forward.log,
+                                    grade: l.message.grade
+                                })
+                                vcIndex[vc] = sheet.length - 1;
+                            }
+                        }
+                    } else if(editors || floGlobals.subAdmins.includes(l.sender) || l.sender === l.message.floID){
+                        if(floCrypto.validateAddr(l.message.floID)){
+                            let vc = l.vectorClock
+                            sheet.push({
+                                vc: vc,
+                                floID: l.message.floID,
+                                log: l.message.log,
+                                grade: null
+                            })
+                            vcIndex[vc] = sheet.length - 1;
+                        }
+                    }
+                }
+            })
             return {
                 title: title,
                 description: floGlobals.appObjects.logSheet.sheetList[title].description,
@@ -10669,55 +10776,52 @@ Bitcoin.Util = {
 
         groupLogsBy: {
 
-            count(title){
+            count(title, sheet){
                 if(!(title in floGlobals.appObjects.logSheet.sheetList))
                     throw ("Sheet not found")
                 let group = {};
-                let filter = floDapps.util.getFilterString(title)
-                floGlobals.generalData[filter].forEach(l => {
-                    if(!(l.message.floID in group))
-                        group[l.message.floID] = 1
+                sheet.forEach(l => {
+                    if(!(l.floID in group))
+                        group[l.floID] = 1
                     else
-                        group[l.message.floID] += 1
+                        group[l.floID] += 1
                 })
                 return group
             },
 
-            total(title, attribute){
+            total(title, sheet, attribute){
                 if(!(title in floGlobals.appObjects.logSheet.sheetList))
                     throw ("Sheet not found")
                 let group = {};
                 let attrubuteIndex = floGlobals.appObjects.logSheet.sheetList[title].attributes.indexOf(attribute)
-                let filter = floDapps.util.getFilterString(title)
-                floGlobals.generalData[filter].forEach(l => {
-                    let value = parseFloat(l.message.log[attrubuteIndex])
+                sheet.forEach(l => {
+                    let value = parseFloat(l.log[attrubuteIndex])
                     if(!isNaN(value)){
-                        if(!(l.message.floID in group))
-                            group[l.message.floID] = value
+                        if(!(l.floID in group))
+                            group[l.floID] = value
                         else
-                            group[l.message.floID] += value
+                            group[l.floID] += value
                     }
                 })
                 return group
             },
 
-            avg(title, attribute){
+            avg(title, sheet, attribute){
                 if(!(title in floGlobals.appObjects.logSheet.sheetList))
                     throw ("Sheet not found")
                 let group = {};
                 let attrubuteIndex = floGlobals.appObjects.logSheet.sheetList[title].attributes.indexOf(attribute)
-                let filter = floDapps.util.getFilterString(title)
-                floGlobals.generalData[filter].forEach(l => {
-                    let value = parseFloat(l.message.log[attrubuteIndex])
+                sheet.forEach(l => {
+                    let value = parseFloat(l.log[attrubuteIndex])
                     if(!isNaN(value)){
-                        if(!(l.message.floID in group))
-                            group[l.message.floID] = {
+                        if(!(l.floID in group))
+                            group[l.floID] = {
                                 total: value,
                                 count: 1
                             }
                         else{
-                            group[l.message.floID].total += value
-                            group[l.message.floID].count += 1
+                            group[l.floID].total += value
+                            group[l.floID].count += 1
                         }
                     }
                 })
@@ -10725,37 +10829,36 @@ Bitcoin.Util = {
                     group[floID] = group[floID].total / group[floID].count
                 return group
             },
-            min(title, attribute){
+
+            min(title, sheet, attribute){
                 if(!(title in floGlobals.appObjects.logSheet.sheetList))
                     throw ("Sheet not found")
                 let group = {};
                 let attrubuteIndex = floGlobals.appObjects.logSheet.sheetList[title].attributes.indexOf(attribute)
-                let filter = floDapps.util.getFilterString(title)
-                floGlobals.generalData[filter].forEach(l => {
-                    let value = parseFloat(l.message.log[attrubuteIndex])
+                sheet.forEach(l => {
+                    let value = parseFloat(l.log[attrubuteIndex])
                     if(!isNaN(value)){
-                        if(!(l.message.floID in group))
-                            group[l.message.floID] = value
-                        else if(value < group[l.message.floID])
-                            group[l.message.floID] = value
+                        if(!(l.floID in group))
+                            group[l.floID] = value
+                        else if(value < group[l.floID])
+                            group[l.floID] = value
                     }
                 })
                 return group
             },
 
-            max(title, attribute){
+            max(title, sheet, attribute){
                 if(!(title in floGlobals.appObjects.logSheet.sheetList))
                     throw ("Sheet not found")
                 let group = {};
                 let attrubuteIndex = floGlobals.appObjects.logSheet.sheetList[title].attributes.indexOf(attribute)
-                let filter = floDapps.util.getFilterString(title)
-                floGlobals.generalData[filter].forEach(l => {
-                    let value = parseFloat(l.message.log[attrubuteIndex])
+                sheet.forEach(l => {
+                    let value = parseFloat(l.log[attrubuteIndex])
                     if(!isNaN(value)){
-                        if(!(l.message.floID in group))
-                            group[l.message.floID] = value
-                        else if(value > group[l.message.floID])
-                            group[l.message.floID] = value
+                        if(!(l.floID in group))
+                            group[l.floID] = value
+                        else if(value > group[l.floID])
+                            group[l.floID] = value
                     }
                 })
                 return group


### PR DESCRIPTION
* logSheet module changes: *
- Adding forward and grade feature: subAdmins in the editor list of respective sheets can forward/grade the logs of others.
(NOTE: Cannot forward/grade own log)
- Made required changes for viewSheets for the above feature.
- Fixed Bug: manageSheetControl didnot have title as argument.
- Passing argument as null for both addList and rmList in manageSheetControl makes the sheet public.
(ie, logSheet.manageSheetControl(title, null, null)
- Passing valid argument (Array of editors) for addList will convert public sheet into controlled.
(ie, logSheet.manageSheetControl(title, [array,of,editors,to,add], null)
- groupBy functions now require the sheet data from viewLogs as parameter. (As constrains are added for logs, direct fetch from generalData wont work).

* UI changes: *
- To create a public sheet, enter 'public' in writers field.
- Grade column will be added for all sheets displaying grade of each log.
(Note: blank = Not graded)
- subAdmins in editor list will be able to grade or regrade (type the grade and click enter)
- Sort table also works for grade